### PR TITLE
Implement the rigt sidebar with lyrics, current-track and queue

### DIFF
--- a/convex/search.ts
+++ b/convex/search.ts
@@ -1,30 +1,32 @@
-import { query } from "./_generated/server";
-import { v } from "convex/values";
+import {query} from "./_generated/server";
+import {v} from "convex/values";
 
 const MAX_SEARCH_RESULTS = 20;
 
 export const getSearchResults = query({
-	args: { searchTerm: v.string() },
+	args: {searchTerm: v.string()},
 	handler: async (ctx, args) => {
 		const tracks = await ctx.db
-			.query("tracks")
-			.withSearchIndex("search_body", (q) => q.search("title", args.searchTerm))
-			.take(MAX_SEARCH_RESULTS);
+				.query("tracks")
+				.withSearchIndex("search_body", (q) => q.search("title", args.searchTerm))
+				.take(MAX_SEARCH_RESULTS);
 
 		const tracksWithArtists = await Promise.all(
-			tracks.map(async (track) => {
-				const artist = await ctx.db.get(track.artistId);
-				return {
-					...track,
-					artist: artist,
-				};
-			})
+				tracks.map(async (track) => {
+					const artist = await ctx.db.get(track.artistId);
+					if (!artist) throw Error("something went wrong");
+
+					return {
+						...track,
+						artist: artist,
+					};
+				})
 		);
 
 		const artists = await ctx.db
-			.query("artists")
-			.withSearchIndex("search_body", (q) => q.search("name", args.searchTerm))
-			.take(MAX_SEARCH_RESULTS);
+				.query("artists")
+				.withSearchIndex("search_body", (q) => q.search("name", args.searchTerm))
+				.take(MAX_SEARCH_RESULTS);
 
 		return {
 			tracks: tracksWithArtists,

--- a/convex/tracks.ts
+++ b/convex/tracks.ts
@@ -26,6 +26,8 @@ export const all = query({
 
 		return await Promise.all(tracks.map(async (track) => {
 			const artist = await ctx.db.get(track.artistId);
+			if (!artist) throw Error("something went wrong");
+
 			return {
 				...track,
 				artist: artist,

--- a/src/components/main-layout.tsx
+++ b/src/components/main-layout.tsx
@@ -2,17 +2,24 @@ import {Outlet} from "react-router";
 import Sidebar from "@/components/sidebar/sidebar.tsx";
 import Player from "@/components/player/player.tsx";
 import Topbar from "@/components/topbar/topbar.tsx";
+import RightSidebar from "@/components/right-sidebar/right-sidebar.tsx";
+import {usePlayerStore} from "@/stores/player-store.ts";
 
 export function MainLayout() {
+	const isRightSidebarOpen = usePlayerStore(state => state.isRightSidebarOpen);
+
 	return (
 			<div className="w-full h-screen bg-black text-foreground flex flex-col">
 				<div className="flex-1 grid grid-cols-[min-content_1fr] gap-2 p-2 pb-0 overflow-hidden">
 					<Sidebar/>
-					<div className="flex flex-col overflow-hidden bg-background rounded-lg">
-						<Topbar/>
-						<div className="flex-1 overflow-y-auto scrollbar scrollbar-track-transparent scrollbar-thumb-neutral-700">
-							<Outlet/>
+					<div className={`flex ${isRightSidebarOpen ? 'gap-2' : ''} overflow-hidden`}>
+						<div className="flex flex-col flex-1 overflow-hidden bg-background rounded-lg">
+							<Topbar/>
+							<div className="flex-1 overflow-y-auto scrollbar scrollbar-track-transparent scrollbar-thumb-neutral-700">
+								<Outlet/>
+							</div>
 						</div>
+						<RightSidebar/>
 					</div>
 				</div>
 				<Player/>

--- a/src/components/player/player-options.tsx
+++ b/src/components/player/player-options.tsx
@@ -1,14 +1,26 @@
 import VolumeBar from "@/components/player/player-volume-bar.tsx";
+import {usePlayerStore} from "@/stores/player-store.ts";
 
 export default function PlayerOptions() {
-	const activeComponent = "CurrentTrack";
+	const isRightSidebarOpen = usePlayerStore(state => state.isRightSidebarOpen);
+	const activeComponent = usePlayerStore(state => state.rightSidebarTab);
+	const toggleRightSidebar = usePlayerStore(state => state.toggleRightSidebar);
+
+	const handleTabClick = (tab: "CurrentTrack" | "Queue" | "Lyrics") => {
+		if (isRightSidebarOpen && activeComponent === tab) {
+			toggleRightSidebar();
+		} else {
+			toggleRightSidebar(tab);
+		}
+	};
 
 	return (
 			<div className="flex items-center justify-end gap-4">
 				<button
-						className={'cursor-pointer group'}
+						onClick={() => handleTabClick("CurrentTrack")}
+						className="cursor-pointer group"
 				>
-					{activeComponent == 'CurrentTrack' ? (
+					{isRightSidebarOpen && activeComponent === 'CurrentTrack' ? (
 							<svg
 									viewBox="0 0 16 16"
 									className="size-4 group-disabled:fill-zinc-600 fill-green-500"
@@ -30,9 +42,10 @@ export default function PlayerOptions() {
 				</button>
 
 				<button
-						className={'cursor-pointer group'}
+						onClick={() => handleTabClick("Lyrics")}
+						className="cursor-pointer group"
 				>
-					{activeComponent == 'Lyrics' ? (
+					{isRightSidebarOpen && activeComponent === 'Lyrics' ? (
 							<svg
 									viewBox="0 0 16 16"
 									className="size-4 fill-green-500 group-disabled:fill-zinc-600"
@@ -52,9 +65,10 @@ export default function PlayerOptions() {
 				</button>
 
 				<button
-						className={'cursor-pointer group'}
+						onClick={() => handleTabClick("Queue")}
+						className="cursor-pointer group"
 				>
-					{activeComponent == 'Queue' ? (
+					{isRightSidebarOpen && activeComponent === 'Queue' ? (
 							<svg
 									viewBox="0 0 16 16"
 									className="size-4 fill-green-500 group-disabled:fill-zinc-600"
@@ -69,27 +83,6 @@ export default function PlayerOptions() {
 							>
 								<path
 										d="M15 15H1v-1.5h14V15zm0-4.5H1V9h14v1.5zm-14-7A2.5 2.5 0 0 1 3.5 1h9a2.5 2.5 0 0 1 0 5h-9A2.5 2.5 0 0 1 1 3.5zm2.5-1a1 1 0 0 0 0 2h9a1 1 0 1 0 0-2h-9z"></path>
-							</svg>
-					)}
-				</button>
-
-				<button
-						className={'cursor-pointer group'}
-				>
-					{activeComponent == 'Devices' ? (
-							<svg viewBox="0 0 16 16" className="size-4 fill-green-500">
-								<path
-										d="M6 2.75C6 1.784 6.784 1 7.75 1h6.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15h-6.5A1.75 1.75 0 0 1 6 13.25V2.75zm1.75-.25a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h6.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25h-6.5zm-6 0a.25.25 0 0 0-.25.25v6.5c0 .138.112.25.25.25H4V11H1.75A1.75 1.75 0 0 1 0 9.25v-6.5C0 1.784.784 1 1.75 1H4v1.5H1.75zM4 15H2v-1.5h2V15z"></path>
-								<path d="M13 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm-1-5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"></path>
-							</svg>
-					) : (
-							<svg
-									viewBox="0 0 16 16"
-									className="size-4 fill-zinc-400 hover:fill-white"
-							>
-								<path
-										d="M6 2.75C6 1.784 6.784 1 7.75 1h6.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15h-6.5A1.75 1.75 0 0 1 6 13.25V2.75zm1.75-.25a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h6.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25h-6.5zm-6 0a.25.25 0 0 0-.25.25v6.5c0 .138.112.25.25.25H4V11H1.75A1.75 1.75 0 0 1 0 9.25v-6.5C0 1.784.784 1 1.75 1H4v1.5H1.75zM4 15H2v-1.5h2V15z"></path>
-								<path d="M13 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm-1-5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"></path>
 							</svg>
 					)}
 				</button>

--- a/src/components/player/player.tsx
+++ b/src/components/player/player.tsx
@@ -28,7 +28,7 @@ export default function Player() {
 	}, [togglePlay]);
 
 	return (
-			<div className="col-span-3 flex justify-between items-center px-1 py-2">
+			<div className="col-span-3 flex justify-between items-center px-2 py-2">
 				<PlayerSongInfo/>
 				<PlayerMain/>
 				<PlayerOptions/>

--- a/src/components/right-sidebar/right-sidebar.tsx
+++ b/src/components/right-sidebar/right-sidebar.tsx
@@ -167,7 +167,7 @@ export default function RightSidebar() {
 																					<DropdownMenuSubContent className="p-0">
 																						<Command>
 																							<CommandInput
-																									placeholder="Playlists filtern..."
+																									placeholder="Filter playlists..."
 																									autoFocus={true}
 																									className="h-9"
 																							/>
@@ -270,7 +270,7 @@ export default function RightSidebar() {
 																					<DropdownMenuSubContent className="p-0">
 																						<Command>
 																							<CommandInput
-																									placeholder="Playlists filtern..."
+																									placeholder="Filter playlists..."
 																									autoFocus={true}
 																									className="h-9"
 																							/>
@@ -363,7 +363,7 @@ export default function RightSidebar() {
 																					<DropdownMenuSubContent className="p-0">
 																						<Command>
 																							<CommandInput
-																									placeholder="Playlists filtern..."
+																									placeholder="Filter Pla..."
 																									autoFocus={true}
 																									className="h-9"
 																							/>

--- a/src/components/right-sidebar/right-sidebar.tsx
+++ b/src/components/right-sidebar/right-sidebar.tsx
@@ -1,0 +1,450 @@
+import {usePlayerStore} from "@/stores/player-store.ts";
+import {Play, Pause, MoreHorizontal, CirclePlus, X} from "lucide-react";
+import type {Id} from "../../../convex/_generated/dataModel";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+import {Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList} from "@/components/ui/command";
+import {useMutation, useQuery} from "convex/react";
+import {api} from "../../../convex/_generated/api";
+import {useState} from "react";
+
+export default function RightSidebar() {
+	const isOpen = usePlayerStore(state => state.isRightSidebarOpen);
+	const activeTab = usePlayerStore(state => state.rightSidebarTab);
+	const queue = usePlayerStore(state => state.window.next);
+	const currentTrack = usePlayerStore(state => state.window.current);
+	const isPlaying = usePlayerStore(state => state.isPlaying);
+
+	const playTrack = usePlayerStore(state => state.playTrack);
+	const playTrackFromQueue = usePlayerStore(state => state.playTrackFromQueue);
+	const pause = usePlayerStore(state => state.pause);
+	const resume = usePlayerStore(state => state.resume);
+
+	const playlists = useQuery(api.playlists.getAllByUser);
+	const addTrack = useMutation(api.playlists.addTrack);
+	const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+
+
+	const track = currentTrack && ("track" in currentTrack ? currentTrack.track : currentTrack);
+	const artist = track?.artist;
+
+	const relatedTracks = useQuery(
+			api.tracks.byArtist,
+			track?.artistId ? {artistId: track.artistId} : "skip"
+	);
+
+	if (!isOpen) return null;
+
+	const otherSongs = relatedTracks
+			? relatedTracks.filter(t => t._id !== track?._id).slice(0, 3)
+			: [];
+
+	const queueTracks = queue.map(item => ("track" in item ? item.track : item));
+
+	const handlePlay = async (trackId: Id<"tracks">) => {
+		const trackIsSelected = track?._id === trackId;
+
+		if (isPlaying && trackIsSelected) {
+			pause();
+		} else if (trackIsSelected) {
+			resume();
+		} else {
+			await playTrack(trackId);
+		}
+	};
+
+	return (
+			<div className="w-80 bg-background rounded-lg flex flex-col overflow-hidden">
+				<div className="flex items-center justify-between p-4 ">
+					<h2 className="text-lg font-semibold">
+						{activeTab === "CurrentTrack" && "Current Track"}
+						{activeTab === "Queue" && "Queue"}
+						{activeTab === "Lyrics" && "Lyrics"}
+					</h2>
+					<button
+							onClick={() => usePlayerStore.setState({isRightSidebarOpen: false})}
+							className="text-muted-foreground hover:text-foreground transition-colors"
+					>
+						<X size={20}/>
+					</button>
+				</div>
+
+				{activeTab === "CurrentTrack" && (
+						<div
+								className="flex-1 overflow-y-auto scrollbar scrollbar-track-transparent scrollbar-thumb-neutral-700 p-4">
+							{track && artist ? (
+									<div className="flex flex-col gap-4">
+										<img
+												src={track.coverUrl}
+												alt={track.title}
+												className="w-full aspect-square rounded-lg object-cover"
+										/>
+										<div>
+											<h2 className="text-2xl font-bold mb-1">{track.title}</h2>
+											<p className="text-sm text-muted-foreground">{artist.name}</p>
+										</div>
+										<div>
+											<div className="bg-muted/30 rounded-lg p-4 cursor-pointer">
+												<h3 className="text-sm font-semibold mb-3">About the artist</h3>
+												<div className="flex items-center gap-3 mb-3">
+													{artist.profilePicUrl && (
+															<img
+																	src={artist.profilePicUrl}
+																	alt={artist.name}
+																	className="size-16 rounded-full object-cover"
+															/>
+													)}
+													<div className="flex-1">
+														<p className="text-base font-semibold">{artist.name}</p>
+														<p className="text-xs text-muted-foreground">7 listeners</p>
+													</div>
+												</div>
+												{artist.description && (
+														<p className="px-2 text-xs text-muted-foreground mt-2">
+															{artist.description}
+														</p>
+												)}
+											</div>
+										</div>
+									</div>
+							) : (
+									<div className="flex items-center justify-center h-full">
+										<p className="text-muted-foreground">No track selected</p>
+									</div>
+							)}
+
+							{otherSongs.length > 0 && (
+									<div className="mt-6">
+										<div className="bg-muted/30 rounded-lg p-4">
+											<h3 className="text-sm font-semibold mb-3">Related Songs</h3>
+											<div className="flex flex-col gap-1">
+												{otherSongs.map((relatedTrack) => (
+														<div
+																key={relatedTrack._id}
+																className="flex items-center gap-3 px-2 py-2 hover:bg-muted/50 rounded-md group transition-colors -mx-2"
+														>
+															<div className="relative flex-shrink-0 cursor-pointer"
+																	 onClick={() => playTrack(relatedTrack._id)}>
+																<img src={relatedTrack.coverUrl} alt={relatedTrack.title}
+																		 className="size-12 rounded group-hover:brightness-75 transition-all"/>
+																<button
+																		className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 hidden group-hover:block"
+																>
+																	<Play size={18} fill="white"/>
+																</button>
+															</div>
+															<div className="min-w-0 flex-1">
+																<div className="text-sm font-medium truncate">
+																	{relatedTrack.title}
+																</div>
+																<div className="text-xs text-muted-foreground truncate">{artist?.name}</div>
+															</div>
+															<div className="flex items-center justify-center">
+																{playlists && (
+																		<DropdownMenu open={openDropdown === `related-${relatedTrack._id}`}
+																									onOpenChange={(isOpen) => setOpenDropdown(isOpen ? `related-${relatedTrack._id}` : null)}>
+																			<DropdownMenuTrigger asChild>
+																				<MoreHorizontal
+																						size={20}
+																						className="text-muted-foreground hover:text-foreground cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+																				/>
+																			</DropdownMenuTrigger>
+
+																			<DropdownMenuContent className="w-40 font-semibold">
+																				<DropdownMenuSub>
+																					<DropdownMenuSubTrigger>
+																						<div className="flex items-center gap-2">
+																							<CirclePlus size={15} className="text-neutral-400"/>
+																							<span className="text-neutral-300">Add to Playlist</span>
+																						</div>
+																					</DropdownMenuSubTrigger>
+																					<DropdownMenuSubContent className="p-0">
+																						<Command>
+																							<CommandInput
+																									placeholder="Playlists filtern..."
+																									autoFocus={true}
+																									className="h-9"
+																							/>
+																							<CommandList>
+																								<CommandEmpty>No Playlist found</CommandEmpty>
+																								<CommandGroup>
+																									{playlists.map((playlist) => (
+																											<CommandItem
+																													key={playlist._id}
+																													value={playlist.name}
+																													onSelect={async (currentValue) => {
+																														const selectedPlaylist = playlists.find(p => p.name === currentValue)
+																														if (selectedPlaylist) {
+																															setOpenDropdown(null)
+																															await addTrack({
+																																playlistId: selectedPlaylist._id,
+																																trackId: relatedTrack._id
+																															})
+																														}
+																													}}
+																											>
+																												<div className="flex items-center gap-2">
+																													<img src={playlist.playlistPicUrl} alt="" width={24}
+																															 height={24}
+																															 className="rounded"/>
+																													<span>{playlist.name}</span>
+																												</div>
+																											</CommandItem>
+																									))}
+																								</CommandGroup>
+																								<CommandEmpty>No Playlist found</CommandEmpty>
+																							</CommandList>
+																						</Command>
+																					</DropdownMenuSubContent>
+																				</DropdownMenuSub>
+																			</DropdownMenuContent>
+																		</DropdownMenu>
+																)}
+															</div>
+														</div>
+												))}
+											</div>
+										</div>
+									</div>
+							)}
+						</div>
+				)}
+
+				{/* Queue Tab */}
+				{activeTab === "Queue" && (
+						<div className="flex-1 overflow-y-auto scrollbar scrollbar-track-transparent scrollbar-thumb-neutral-700">
+							<div className="px-4">
+								{currentTrack && track && (
+										<div className="mb-5">
+											<h3 className="text-sm font-semibold text-muted-foreground mb-2">Now Playing</h3>
+											{(() => {
+												const dropdownId = `current-${track._id}`;
+												return (
+														<div
+																key={track._id}
+																className="flex items-center gap-3 px-2 py-2 hover:bg-muted/50 rounded-md group transition-colors -mx-2"
+														>
+															<div className="relative flex-shrink-0 cursor-pointer"
+																	 onClick={() => handlePlay(track._id)}>
+																<img src={track.coverUrl} alt={track.title}
+																		 className="size-10 rounded group-hover:brightness-75 transition-all"/>
+																<button
+																		className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 hidden group-hover:block"
+																>
+																	{isPlaying ? <Pause size={18} fill="white"/> :
+																			<Play size={18} fill="white"/>}
+																</button>
+															</div>
+															<div className="min-w-0 flex-1">
+																<div
+																		className="text-sm font-medium truncate text-green-500">
+																	{track.title}
+																</div>
+																<div className="text-xs text-muted-foreground truncate">{artist?.name}</div>
+															</div>
+															<div className="flex items-center justify-center">
+																{playlists && (
+																		<DropdownMenu open={openDropdown === dropdownId}
+																									onOpenChange={(isOpen) => setOpenDropdown(isOpen ? dropdownId : null)}>
+																			<DropdownMenuTrigger asChild>
+																				<MoreHorizontal
+																						size={20}
+																						className="text-muted-foreground hover:text-foreground cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+																				/>
+																			</DropdownMenuTrigger>
+
+																			<DropdownMenuContent className="w-40 font-semibold">
+																				<DropdownMenuSub>
+																					<DropdownMenuSubTrigger>
+																						<div className="flex items-center gap-2">
+																							<CirclePlus size={15} className="text-neutral-400"/>
+																							<span className="text-neutral-300">Add to Playlist</span>
+																						</div>
+																					</DropdownMenuSubTrigger>
+																					<DropdownMenuSubContent className="p-0">
+																						<Command>
+																							<CommandInput
+																									placeholder="Playlists filtern..."
+																									autoFocus={true}
+																									className="h-9"
+																							/>
+																							<CommandList>
+																								<CommandEmpty>No Playlist found</CommandEmpty>
+																								<CommandGroup>
+																									{playlists.map((playlist) => (
+																											<CommandItem
+																													key={playlist._id}
+																													value={playlist.name}
+																													onSelect={async (currentValue) => {
+																														const selectedPlaylist = playlists.find(p => p.name === currentValue)
+																														if (selectedPlaylist) {
+																															setOpenDropdown(null)
+																															await addTrack({
+																																playlistId: selectedPlaylist._id,
+																																trackId: track._id
+																															})
+																														}
+																													}}
+																											>
+																												<div className="flex items-center gap-2">
+																													<img src={playlist.playlistPicUrl} alt="" width={24}
+																															 height={24}
+																															 className="rounded"/>
+																													<span>{playlist.name}</span>
+																												</div>
+																											</CommandItem>
+																									))}
+																								</CommandGroup>
+																							</CommandList>
+																						</Command>
+																					</DropdownMenuSubContent>
+																				</DropdownMenuSub>
+																			</DropdownMenuContent>
+																		</DropdownMenu>
+																)}
+															</div>
+														</div>
+												);
+											})()}
+										</div>
+								)}
+								{queueTracks.length > 0 && (
+										<div>
+											<h3 className="text-sm font-semibold text-muted-foreground mb-2">Next</h3>
+											{queueTracks.map((queueTrack, index) => {
+												const dropdownId = `queue-${index}-${queueTrack._id}`;
+												return (
+														<div
+																key={`${index}-${queueTrack._id}`}
+																className="flex items-center gap-3 px-2 py-2 hover:bg-muted/50 rounded-md group transition-colors -mx-2"
+														>
+															<div className="relative flex-shrink-0 cursor-pointer"
+																	 onClick={() => playTrackFromQueue(queueTrack._id)}>
+																<img src={queueTrack.coverUrl} alt={queueTrack.title}
+																		 className="size-10 rounded group-hover:brightness-75 transition-all"/>
+																<button
+																		className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 hidden group-hover:block"
+																>
+																	<Play size={18} fill="white"/>
+																</button>
+															</div>
+															<div className="min-w-0 flex-1">
+																<div
+																		className="text-sm font-medium truncate ">
+																	{queueTrack.title}
+																</div>
+																<div className="text-xs text-muted-foreground truncate">{queueTrack.artist.name}</div>
+															</div>
+															<div className="flex items-center justify-center">
+																{playlists && (
+																		<DropdownMenu open={openDropdown === dropdownId}
+																									onOpenChange={(isOpen) => setOpenDropdown(isOpen ? dropdownId : null)}>
+																			<DropdownMenuTrigger asChild>
+																				<MoreHorizontal
+																						size={20}
+																						className="text-muted-foreground hover:text-foreground cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+																				/>
+																			</DropdownMenuTrigger>
+
+																			<DropdownMenuContent className="w-40 font-semibold">
+																				<DropdownMenuSub>
+																					<DropdownMenuSubTrigger>
+																						<div className="flex items-center gap-2">
+																							<CirclePlus size={15} className="text-neutral-400"/>
+																							<span className="text-neutral-300">Add to Playlist</span>
+																						</div>
+																					</DropdownMenuSubTrigger>
+																					<DropdownMenuSubContent className="p-0">
+																						<Command>
+																							<CommandInput
+																									placeholder="Playlists filtern..."
+																									autoFocus={true}
+																									className="h-9"
+																							/>
+																							<CommandList>
+																								<CommandEmpty>No Playlist found</CommandEmpty>
+																								<CommandGroup>
+																									{playlists.map((playlist) => (
+																											<CommandItem
+																													key={playlist._id}
+																													value={playlist.name}
+																													onSelect={async (currentValue) => {
+																														const selectedPlaylist = playlists.find(p => p.name === currentValue)
+																														if (selectedPlaylist) {
+																															setOpenDropdown(null)
+																															await addTrack({
+																																playlistId: selectedPlaylist._id,
+																																trackId: queueTrack._id
+																															})
+																														}
+																													}}
+																											>
+																												<div className="flex items-center gap-2">
+																													<img src={playlist.playlistPicUrl} alt="" width={24}
+																															 height={24}
+																															 className="rounded"/>
+																													<span>{playlist.name}</span>
+																												</div>
+																											</CommandItem>
+																									))}
+																								</CommandGroup>
+																							</CommandList>
+																						</Command>
+																					</DropdownMenuSubContent>
+																				</DropdownMenuSub>
+																			</DropdownMenuContent>
+																		</DropdownMenu>
+																)}
+															</div>
+														</div>
+												);
+											})}
+										</div>
+								)
+								}
+							</div>
+						</div>
+				)}
+
+				{activeTab === "Lyrics" && (
+						<div
+								className="flex-1 overflow-y-auto scrollbar scrollbar-track-transparent scrollbar-thumb-neutral-700 p-4 pt-0">
+							{track ? (
+									<>
+										{track.lyrics && track.lyrics.trim() !== "" ? (
+												<div className="mt-4">
+													<pre className="whitespace-pre-wrap text-sm leading-7 font-sans">
+														{track.lyrics}
+													</pre>
+												</div>
+										) : (
+												<div className="flex items-center justify-center h-64">
+													<div className="text-center">
+														<svg
+																viewBox="0 0 16 16"
+																className="size-12 fill-neutral-600 mx-auto mb-4"
+														>
+															<path
+																	d="M13.426 2.574a2.831 2.831 0 0 0-4.797 1.55l3.247 3.247a2.831 2.831 0 0 0 1.55-4.797zM10.5 8.118l-2.619-2.62A63303.13 63303.13 0 0 0 4.74 9.075L2.065 12.12a1.287 1.287 0 0 0 1.816 1.816l3.06-2.688 3.56-3.129zM7.12 4.094a4.331 4.331 0 1 1 4.786 4.786l-3.974 3.493-3.06 2.689a2.787 2.787 0 0 1-3.933-3.933l2.676-3.045 3.505-3.99z"></path>
+														</svg>
+														<p className="text-muted-foreground text-sm">No Lyrics found</p>
+													</div>
+												</div>
+										)}
+									</>
+							) : (
+									<div className="flex items-center justify-center h-full">
+										<p className="text-muted-foreground">No Track selected</p>
+									</div>
+							)}
+						</div>
+				)}
+			</div>
+	);
+}

--- a/src/components/song-list.tsx
+++ b/src/components/song-list.tsx
@@ -1,144 +1,146 @@
-import type { TrackFull } from "../../convex/tracks"
-import { Play, Pause, MoreHorizontal, CirclePlus } from "lucide-react"
-import { usePlayerStore } from "@/stores/player-store"
+import type {TrackFull} from "../../convex/tracks"
+import {Play, Pause, MoreHorizontal, CirclePlus} from "lucide-react"
+import {usePlayerStore} from "@/stores/player-store"
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
-import { useMutation, useQuery } from "convex/react"
-import { api } from "../../convex/_generated/api"
-import { useState } from "react"
+import {Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList} from "@/components/ui/command"
+import {useMutation, useQuery} from "convex/react"
+import {api} from "../../convex/_generated/api"
+import {useState} from "react"
+import type {Id} from "../../convex/_generated/dataModel";
 
 interface SongListProps {
-  songs: TrackFull[]
+	songs: TrackFull[]
 }
 
-export default function SongList({ songs }: SongListProps) {
-  const currentTrack = usePlayerStore(state => state.window.current)
-  const isPlaying = usePlayerStore(state => state.isPlaying)
-  const playTrack = usePlayerStore(state => state.playTrack)
-  const pause = usePlayerStore(state => state.pause)
-  const resume = usePlayerStore(state => state.resume)
+export default function SongList({songs}: SongListProps) {
+	const currentTrack = usePlayerStore(state => state.window.current)
+	const isPlaying = usePlayerStore(state => state.isPlaying)
+	const playTrack = usePlayerStore(state => state.playTrack)
+	const pause = usePlayerStore(state => state.pause)
+	const resume = usePlayerStore(state => state.resume)
 
-  const playlists = useQuery(api.playlists.getAllByUser)
-  const addTrack = useMutation(api.playlists.addTrack)
-  const [openDropdown, setOpenDropdown] = useState<string | null>(null)
+	const playlists = useQuery(api.playlists.getAllByUser)
+	const addTrack = useMutation(api.playlists.addTrack)
+	const [openDropdown, setOpenDropdown] = useState<string | null>(null)
 
-  const handlePlay = async (trackId: string) => {
-    const trackIsSelected = currentTrack?._id === trackId
+	const handlePlay = async (trackId: Id<"tracks">) => {
+		const trackIsSelected = currentTrack?._id === trackId
 
-    if (isPlaying && trackIsSelected) {
-      pause()
-    } else if (trackIsSelected) {
-      resume()
-    } else {
-      await playTrack(trackId)
-    }
-  }
+		if (isPlaying && trackIsSelected) {
+			pause()
+		} else if (trackIsSelected) {
+			resume()
+		} else {
+			await playTrack(trackId)
+		}
+	}
 
-  if (!playlists) return null
+	if (!playlists) return null
 
-  return (
-    <div className="space-y-1">
-      {songs.map((song, index) => {
-        const trackIsSelected = currentTrack?._id === song._id
+	return (
+			<div className="space-y-1">
+				{songs.map((song, index) => {
+					const trackIsSelected = currentTrack?._id === song._id
 
-        return (
-          <div
-            key={song._id}
-            className="grid grid-cols-[16px_1fr_40px] gap-4 px-4 py-2 hover:bg-muted/50 rounded-md group transition-colors"
-          >
-            <div className="flex items-center justify-center text-muted-foreground">
-              <button
-                className="cursor-pointer"
-                onClick={() => handlePlay(song._id)}
-              >
+					return (
+							<div
+									key={song._id}
+									className="grid grid-cols-[16px_1fr_40px] gap-4 px-2 py-2 hover:bg-muted/50 rounded-md group transition-colors"
+							>
+								<div className="flex items-center justify-center text-muted-foreground">
+									<button
+											className="cursor-pointer"
+											onClick={() => handlePlay(song._id)}
+									>
                 <span
-                  className={`group-hover:hidden text-sm font-semibold ${trackIsSelected ? 'text-green-500' : ''}`}
-                >
+										className={`group-hover:hidden text-sm font-semibold ${trackIsSelected ? 'text-green-500' : ''}`}
+								>
                   {index + 1}
                 </span>
-                <span className="hidden group-hover:block text-foreground">
-                  {isPlaying && trackIsSelected ? <Pause size={18} /> : <Play size={18} />}
+										<span className="hidden group-hover:block text-foreground">
+                  {isPlaying && trackIsSelected ? <Pause size={18}/> : <Play size={18}/>}
                 </span>
-              </button>
-            </div>
+									</button>
+								</div>
 
-            <div className="flex items-center min-w-0 gap-3">
-              <img src={song.coverUrl} alt="" className="size-11 rounded" />
-              <div className="min-w-0">
-                <div className={`font-medium truncate ${trackIsSelected ? 'text-green-500' : ''}`}>
-                  {song.title}
-                </div>
-                <div className="text-sm text-muted-foreground truncate">{song.artist.name}</div>
-              </div>
-            </div>
+								<div className="flex items-center min-w-0 gap-3">
+									<img src={song.coverUrl} alt="" className="size-11 rounded"/>
+									<div className="min-w-0">
+										<div className={`font-medium truncate ${trackIsSelected ? 'text-green-500' : ''}`}>
+											{song.title}
+										</div>
+										<div className="text-sm text-muted-foreground truncate">{song.artist.name}</div>
+									</div>
+								</div>
 
-            <div className="flex items-center justify-center">
-              <DropdownMenu open={openDropdown === song._id} onOpenChange={(isOpen) => setOpenDropdown(isOpen ? song._id : null)}>
-                <DropdownMenuTrigger asChild>
-                  <MoreHorizontal
-                    size={22}
-                    className="text-muted-foreground hover:text-foreground cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
-                  />
-                </DropdownMenuTrigger>
+								<div className="flex items-center justify-center">
+									<DropdownMenu open={openDropdown === song._id}
+																onOpenChange={(isOpen) => setOpenDropdown(isOpen ? song._id : null)}>
+										<DropdownMenuTrigger asChild>
+											<MoreHorizontal
+													size={22}
+													className="text-muted-foreground hover:text-foreground cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity"
+											/>
+										</DropdownMenuTrigger>
 
-                <DropdownMenuContent className="w-40 font-semibold">
-                  <DropdownMenuSub>
-                    <DropdownMenuSubTrigger>
-                      <div className="flex items-center gap-2">
-                        <CirclePlus size={15} className="text-neutral-400" />
-                        <span className="text-neutral-300">Add to Playlist</span>
-                      </div>
-                    </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent className="p-0">
-                      <Command>
-                        <CommandInput
-                          placeholder="Filter playlists..."
-                          autoFocus={true}
-                          className="h-9"
-                        />
-                        <CommandList>
-                          <CommandEmpty>No playlist found.</CommandEmpty>
-                          <CommandGroup>
-                            {playlists.map((playlist) => (
-                              <CommandItem
-                                key={playlist._id}
-                                value={playlist.name}
-                                onSelect={async (currentValue) => {
-                                  const selectedPlaylist = playlists.find(p => p.name === currentValue)
-                                  if (selectedPlaylist) {
-                                    setOpenDropdown(null)
-                                    await addTrack({
-                                      playlistId: selectedPlaylist._id,
-                                      trackId: song._id
-                                    })
-                                  }
-                                }}
-                              >
-                                <div className="flex items-center gap-2">
-                                  <img src={playlist.playlistPicUrl} alt="" width={24} height={24} className="rounded" />
-                                  <span>{playlist.name}</span>
-                                </div>
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </DropdownMenuSubContent>
-                  </DropdownMenuSub>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-        )
-      })}
-    </div>
-  )
+										<DropdownMenuContent className="w-40 font-semibold">
+											<DropdownMenuSub>
+												<DropdownMenuSubTrigger>
+													<div className="flex items-center gap-2">
+														<CirclePlus size={15} className="text-neutral-400"/>
+														<span className="text-neutral-300">Add to Playlist</span>
+													</div>
+												</DropdownMenuSubTrigger>
+												<DropdownMenuSubContent className="p-0">
+													<Command>
+														<CommandInput
+																placeholder="Filter playlists..."
+																autoFocus={true}
+																className="h-9"
+														/>
+														<CommandList>
+															<CommandEmpty>No playlist found.</CommandEmpty>
+															<CommandGroup>
+																{playlists.map((playlist) => (
+																		<CommandItem
+																				key={playlist._id}
+																				value={playlist.name}
+																				onSelect={async (currentValue) => {
+																					const selectedPlaylist = playlists.find(p => p.name === currentValue)
+																					if (selectedPlaylist) {
+																						setOpenDropdown(null)
+																						await addTrack({
+																							playlistId: selectedPlaylist._id,
+																							trackId: song._id
+																						})
+																					}
+																				}}
+																		>
+																			<div className="flex items-center gap-2">
+																				<img src={playlist.playlistPicUrl} alt="" width={24} height={24}
+																						 className="rounded"/>
+																				<span>{playlist.name}</span>
+																			</div>
+																		</CommandItem>
+																))}
+															</CommandGroup>
+														</CommandList>
+													</Command>
+												</DropdownMenuSubContent>
+											</DropdownMenuSub>
+										</DropdownMenuContent>
+									</DropdownMenu>
+								</div>
+							</div>
+					)
+				})}
+			</div>
+	)
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
 @import "tw-animate-css";
 
 @plugin 'tailwind-scrollbar' {
-  nocompatible: true;
+    nocompatible: true;
 }
 
 @custom-variant dark (&:is(.dark *));
@@ -126,10 +126,11 @@
 
 @layer utilities {
     .scrollbar-hide {
-        -ms-overflow-style: none;  /* Internet Explorer 10+ */
-        scrollbar-width: none;  /* Firefox */
+        -ms-overflow-style: none; /* Internet Explorer 10+ */
+        scrollbar-width: none; /* Firefox */
     }
+
     .scrollbar-hide::-webkit-scrollbar {
-        display: none;  /* Safari and Chrome */
+        display: none; /* Safari and Chrome */
     }
 }

--- a/src/pages/main-content.tsx
+++ b/src/pages/main-content.tsx
@@ -5,11 +5,20 @@ import {
 	ContextMenu,
 	ContextMenuContent,
 	ContextMenuItem,
-	ContextMenuTrigger
+	ContextMenuSub,
+	ContextMenuSubContent,
+	ContextMenuSubTrigger,
+	ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover";
 import {CirclePlus} from "lucide-react";
-import {Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList} from "@/components/ui/command.tsx";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command.tsx";
 import {useState} from "react";
 
 export default function MainContent() {
@@ -17,7 +26,7 @@ export default function MainContent() {
 	const playlists = useQuery(api.playlists.getAllByUser);
 	const addTrack = useMutation(api.playlists.addTrack);
 
-	const [open, setOpen] = useState(false)
+	const [openContextMenu, setOpenContextMenu] = useState<string | null>(null);
 
 	if (!tracks || !playlists) {
 		return <h1>Loading...</h1>;
@@ -28,66 +37,68 @@ export default function MainContent() {
 				<div className="overflow-x-auto overflow-y-hidden scrollbar-hide">
 					<div className="flex gap-4 pb-2 w-max">
 						{tracks.slice(0, 10).map((track) => (
-								<Popover open={open} onOpenChange={setOpen} key={track._id}>
-									<ContextMenu>
-										<ContextMenuTrigger className="flex-shrink-0 w-[200px]">
-											<SongCard
-													track={track}
-													artist={track.artist}
-											/>
-										</ContextMenuTrigger>
+								<ContextMenu
+										key={track._id}
+										onOpenChange={(isOpen) => setOpenContextMenu(isOpen ? track._id : null)}
+								>
+									<ContextMenuTrigger className="flex-shrink-0 w-[200px]">
+										<SongCard track={track} artist={track.artist}/>
+									</ContextMenuTrigger>
 
-										<ContextMenuContent className="w-52">
-											<ContextMenuItem>
-												<PopoverTrigger asChild>
-													<div className="flex items-center gap-2 ">
-														<CirclePlus size={15} className="text-neutral-400"/>
-														<span className="text-neutral-300">Add to Playlist</span>
-													</div>
-												</PopoverTrigger>
-											</ContextMenuItem>
-										</ContextMenuContent>
-									</ContextMenu>
-									<PopoverContent>
-										<Command>
-											<CommandInput
-													placeholder="Filter playlists..."
-													autoFocus={true}
-													className="h-9"
-											/>
-											<CommandList>
-												<CommandEmpty>No playlist found.</CommandEmpty>
-												<CommandGroup>
-													{playlists
-															.map((playlist) => (
+									<ContextMenuContent className="w-52">
+										<ContextMenuSub>
+											<ContextMenuSubTrigger>
+												<div className="flex items-center gap-2">
+													<CirclePlus size={15} className="text-neutral-400"/>
+													<span className="text-neutral-300">Add to Playlist</span>
+												</div>
+											</ContextMenuSubTrigger>
+											<ContextMenuSubContent className="p-0 w-64">
+												<Command>
+													<CommandInput
+															placeholder="Filter playlists..."
+															autoFocus={true}
+															className="h-9"
+													/>
+													<CommandList>
+														<CommandEmpty>No playlist found.</CommandEmpty>
+														<CommandGroup>
+															{playlists.map((playlist) => (
 																	<CommandItem
 																			key={playlist._id}
 																			value={playlist.name}
 																			onSelect={async (currentValue) => {
-																				const selectedPlaylist = playlists.find(p => p.name === currentValue);
+																				const selectedPlaylist = playlists.find(
+																						(p) => p.name === currentValue
+																				);
 																				if (selectedPlaylist) {
-																					setOpen(false);
+																					setOpenContextMenu(null);
 																					await addTrack({
 																						playlistId: selectedPlaylist._id,
-																						trackId: track._id
+																						trackId: track._id,
 																					});
 																				}
 																			}}
 																	>
 																		<div className="flex items-center gap-2">
-																			<img src={playlist.playlistPicUrl} alt="" width={24} height={24}
-																					 className="rounded"/>
+																			<img
+																					src={playlist.playlistPicUrl}
+																					alt=""
+																					width={24}
+																					height={24}
+																					className="rounded"
+																			/>
 																			<span>{playlist.name}</span>
-
 																		</div>
 																	</CommandItem>
 															))}
-												</CommandGroup>
-											</CommandList>
-										</Command>
-									</PopoverContent>
-								</Popover>
-
+														</CommandGroup>
+													</CommandList>
+												</Command>
+											</ContextMenuSubContent>
+										</ContextMenuSub>
+									</ContextMenuContent>
+								</ContextMenu>
 						))}
 					</div>
 				</div>


### PR DESCRIPTION
This pull request adds a right sidebar with tabbed content (Current Track, Queue, Lyrics), enhancing queue navigation and playback.
* Added a right sidebar component (`RightSidebar`) to the main layout, controlled by new state in `player-store`. The sidebar supports tab switching between "CurrentTrack", "Queue", and "Lyrics", and can be toggled from the player options. 
**Playback Queue Improvements:**

* Added `playTrackFromQueue` to `player-store`, allowing direct playback of any track from the queue, updating the window and playback state accordingly. 
* Fixed previous track navigation to correctly move to the last item in the previous queue, rather than the first, and update the current/next/previous windows accurately. 

Closes #17 